### PR TITLE
feat: ansible=14.0.0,base=4.6.0,add=alpine_3.24,debian_forky,ubuntu_questing,drop=debian_bookworm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# bradfordwagner/container-ansible
+
+Builds multi-arch Ansible container images on top of `ghcr.io/bradfordwagner/base` using Dagger.
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `config.yaml` | OS targets, archs, upstream base tag |
+| `install_ansible.sh` | Installs Ansible into a venv at `/ansible_env` |
+| `Dockerfile` | Thin wrapper — copies src, runs install script, sets PATH |
+| `playbook.yml` | Smoke-tests binaries and runs `andrewrothstein.ca_certs` role |
+| `requirements.yml` | Ansible Galaxy deps (`andrewrothstein.ca_certs`) |
+
+## Upgrading Ansible
+
+1. Update `ansible_version` in `install_ansible.sh`
+2. Update `python_verson` (for RHEL builds) in `install_ansible.sh`
+3. Check OS Python compatibility — Ansible 14+ requires Python >= 3.12
+
+## OS Python compatibility
+
+| OS | Python | Min Ansible |
+|---|---|---|
+| alpine_3.22 | 3.12 | 14 |
+| alpine_3.23 | 3.12 | 14 |
+| alpine_3.24 | 3.14 | 14 |
+| archlinux_latest | 3.13+ (rolling) | 14 |
+| debian_bookworm | 3.11 | 12 only — excluded (Python < 3.12) |
+| debian_trixie | 3.13 | 14 |
+| debian_trixie-slim | 3.13 | 14 |
+| debian_forky | 3.13 | 14 |
+| debian_forky-slim | 3.13 | 14 |
+| ubuntu_noble | 3.12 | 14 |
+| ubuntu_plucky | 3.13 | 14 |
+| ubuntu_questing | 3.13 | 14 |
+
+`debian_bookworm` and `debian_bookworm-slim` are intentionally excluded — their system Python (3.11) does not meet Ansible 14's `>=3.12` requirement.
+
+## CI
+
+- **Branch pushes** → `container-branches.yml` builds with `version=latest`
+- **Tag pushes** → `container-tags.yml` builds and pushes versioned + manifest
+- Uses `dagger-container-builds@0.1.1` module via Dagger 0.15.2
+- Watch runs: `gh run list --branch <branch> --limit 5`

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@ target_repo: ghcr.io/bradfordwagner/ansible
 flavor: custom
 upstream:
   repo: ghcr.io/bradfordwagner/base
-  tag: 4.3.1
+  tag: 4.6.0
 builds:
   - os: alpine_3.22
     archs:
@@ -11,6 +11,12 @@ builds:
     args:
       pkg_installer: alpine
   - os: alpine_3.23
+    archs:
+      - linux/amd64
+      - linux/arm64
+    args:
+      pkg_installer: alpine
+  - os: alpine_3.24
     archs:
       - linux/amd64
       - linux/arm64
@@ -33,6 +39,18 @@ builds:
       - linux/arm64
     args:
       pkg_installer: debian
+  - os: debian_forky
+    archs:
+      - linux/amd64
+      - linux/arm64
+    args:
+      pkg_installer: debian
+  - os: debian_forky-slim
+    archs:
+      - linux/amd64
+      - linux/arm64
+    args:
+      pkg_installer: debian
   - os: ubuntu_noble
     archs:
       - linux/amd64
@@ -40,6 +58,12 @@ builds:
     args:
       pkg_installer: debian
   - os: ubuntu_plucky
+    archs:
+      - linux/amd64
+      - linux/arm64
+    args:
+      pkg_installer: debian
+  - os: ubuntu_questing
     archs:
       - linux/amd64
       - linux/arm64

--- a/config.yaml
+++ b/config.yaml
@@ -21,18 +21,6 @@ builds:
       - linux/amd64
     args:
       pkg_installer: arch
-  - os: debian_bookworm
-    archs:
-      - linux/amd64
-      - linux/arm64
-    args:
-      pkg_installer: debian
-  - os: debian_bookworm-slim
-    archs:
-      - linux/amd64
-      - linux/arm64
-    args:
-      pkg_installer: debian
   - os: debian_trixie
     archs:
       - linux/amd64

--- a/install_ansible.sh
+++ b/install_ansible.sh
@@ -65,7 +65,7 @@ rhel_deps() {
 
   # maybe we should be installing python for all os
   # https://www.python.org/doc/versions/
-  python_verson=3.12.12
+  python_verson=3.12.13
   wget https://www.python.org/ftp/python/${python_verson}/Python-${python_verson}.tar.xz
   xz -d -v Python-${python_verson}.tar.xz
   tar xf Python-${python_verson}.tar
@@ -96,7 +96,7 @@ python3 get-pip.py
 
 # ansible + ansible core versions
 # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs
-ansible_version=12.3.0
+ansible_version=14.0.0
 python3 -m pip install ansible==${ansible_version}
 
 # smoketest


### PR DESCRIPTION
## Summary
- Upgrade Ansible 12.3.0 → 14.0.0 (requires Python >= 3.12, ansible-core ~= 2.21.0)
- Bump base image 4.3.1 → 4.6.0
- Add new OS targets: alpine_3.24, debian_forky, debian_forky-slim, ubuntu_questing
- Drop debian_bookworm and debian_bookworm-slim (Python 3.11 does not meet Ansible 14's >= 3.12 requirement)
- Add CLAUDE.md with OS compatibility table and upgrade notes